### PR TITLE
Fixing catalog.query limit and adding complete argument.

### DIFF
--- a/tests/test_maxarcat.py
+++ b/tests/test_maxarcat.py
@@ -62,9 +62,9 @@ class TestCatalog:
         start = datetime(year=2020, month=1, day=1, hour=12)
         end = datetime(year=2020, month=1, day=2, hour=15)
         collection = 'wv02'
-        features = catalog.query(collections=[collection], start_datetime=start, end_datetime=end)
+        feature_coll = catalog.search(collections=[collection], start_datetime=start, end_datetime=end)
         count = 0
-        for feature in features:
+        for feature in feature_coll.features:
             dt = TestCatalog.parse_datetime_iso8601(feature.properties['datetime'])
             assert start <= dt < end
             assert feature.collection == collection
@@ -199,9 +199,9 @@ class TestCatalog:
         # per page.  Assume that's still the case and perform a query
         # that should return thousands of items.  Stop after we've read
         # what should be a few pages.
-        feature_coll = catalog.search(bbox=[-100, 40, -105, 45])
+        features = catalog.query(bbox=[-100, 40, -105, 45])
         count = 0
-        for _ in feature_coll.features:
+        for _ in features:
             count += 1
             if count >= 500:
                 break


### PR DESCRIPTION
The `catalog.query` method attempts to handle the paging of results, but `limit` applies to the page rather than to the whole collection. Here is an example:
```
from dateutil import parser
from maxarcat import Catalog

catalog = Catalog(token)
features = catalog.query(
    bbox=[
        -81,
        28,
        -80,
        29,
    ],
    start_datetime=parser.parse("2018-01-01"),
    end_datetime=parser.parse("2022-01-01"),
    limit=100,
)
temp = list(features)
print(len(temp))
```
This example should print 100 but instead prints 1538. Also the `complete` argument is missing.